### PR TITLE
feat: 3180 fix fps in referer

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -280,3 +280,37 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "932200"
+  - test_title: 932200-18
+    desc: False positive test against query string and space in a parameter
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "http://www.example.com/page?param=test+test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932205"
+  - test_title: 932200-19
+    desc: False positive test against query string and space in path
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "http://www.example.com/page%20test?param=test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932205"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -296,7 +296,7 @@ tests:
             uri: /get
             version: HTTP/1.0
           output:
-            no_log_contains: id "932205"
+            no_log_contains: id "932200"
   - test_title: 932200-19
     desc: False positive test against query string and space in path
     stages:
@@ -313,4 +313,4 @@ tests:
             uri: /get
             version: HTTP/1.0
           output:
-            no_log_contains: id "932205"
+            no_log_contains: id "932200"


### PR DESCRIPTION
PR copies across the new false positive tests so that they also test against rule 932200, which is the rule that was originally causing the false positive problem.